### PR TITLE
refactor: [IWP-120] improved unprotectedheader decoding in cose objects

### DIFF
--- a/IOWalletCBOR/IOWalletCBOR/COSE/Cose.swift
+++ b/IOWalletCBOR/IOWalletCBOR/COSE/Cose.swift
@@ -58,8 +58,21 @@ extension Cose {
   /// Cose header structure defined in https://datatracker.ietf.org/doc/html/rfc8152
   struct CoseHeader {
     enum Headers : Int {
-      case keyId = 4
-      case algorithm = 1
+        
+        //https://datatracker.ietf.org/doc/html/rfc8152 -> Table 2: Common Header Parameters
+        case alg = 1
+        case crit = 2
+        case content_type = 3
+        case kid = 4
+        case iv = 5
+        case partial_iv = 6
+        case counter_signature = 7
+        
+        //https://datatracker.ietf.org/doc/html/rfc9360 -> Table 1: X.509 COSE Header Parameters
+        case x5bag = 32
+        case x5chain = 33
+        case x5t = 34
+        case x5u = 35
     }
     
     let rawHeader : CBOR?
@@ -71,11 +84,11 @@ extension Cose {
     /// - Parameter cbor: CBOR representation of the header
     init?(fromBytestring cbor: CBOR){
       guard let cborMap = cbor.decodeBytestring()?.asMap(),
-            let alg = cborMap[Headers.algorithm]?.asUInt64() else {
+            let alg = cborMap[Headers.alg]?.asUInt64() else {
         self.init(alg: nil, isNegativeAlg: nil, keyId: nil, rawHeader: cbor)
         return
       }
-      self.init(alg: alg, isNegativeAlg: nil, keyId: cborMap[Headers.keyId]?.asBytes(), rawHeader: cbor)
+      self.init(alg: alg, isNegativeAlg: nil, keyId: cborMap[Headers.kid]?.asBytes(), rawHeader: cbor)
     }
     
     init?(alg: UInt64?, isNegativeAlg: Bool?, keyId: [UInt8]?, rawHeader : CBOR? = nil){
@@ -83,7 +96,7 @@ extension Cose {
       self.algorithm = alg
       self.keyId = keyId
       func algCbor() -> CBOR { isNegativeAlg! ? .negativeInt(alg!) : .unsignedInt(alg!) }
-      self.rawHeader = rawHeader ?? .byteString(CBOR.map([.unsignedInt(UInt64(Headers.algorithm.rawValue)) : algCbor()]).encode())
+      self.rawHeader = rawHeader ?? .byteString(CBOR.map([.unsignedInt(UInt64(Headers.alg.rawValue)) : algCbor()]).encode())
     }
   }
 }

--- a/IOWalletCBOR/IOWalletCBOR/CborCose.swift
+++ b/IOWalletCBOR/IOWalletCBOR/CborCose.swift
@@ -192,21 +192,32 @@ public class CborCose {
                         keyPair in
                         
                         let keyStr: String
+                        var value: AnyHashable? = cborToJson(cborObject: keyPair.value, isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true)
                         
                         if let key = keyPair.key.asUInt64(),
                            let header = Cose.CoseHeader.Headers(rawValue: Int(key)) {
                             keyStr = "\(header)"
                             
+                            switch(header) {
+                                case .x5chain, .x5bag:
+                                    //if header is x5chain or x5bag and value is not array transform it to array
+                                    if !(value is [AnyHashable?]) {
+                                        value = [value]
+                                    }
+                                    break
+                                default:
+                                    break
+                            }
                         } else {
+                            //when header is not in the enum map it as the int value
                             if let keyValue = cborToJson(cborObject: keyPair.key, isKey: true, properIssuerItem: properIssuerItem, decodeIssuerAuth: true)  {
                                 keyStr = "\(keyValue)"
                             } else {
                                 keyStr = "\(keyPair.key)"
                             }
                         }
-                        
                         return [
-                            keyStr: cborToJson(cborObject: keyPair.value, isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true)
+                            keyStr: value
                         ]
                     })
                 ,

--- a/IOWalletCBOR/IOWalletCBOR/CborCose.swift
+++ b/IOWalletCBOR/IOWalletCBOR/CborCose.swift
@@ -190,9 +190,23 @@ public class CborCose {
                 "unprotectedHeader":
                     issuerAuthCose.unprotectedHeader?.rawHeader?.asMap()?.map({
                         keyPair in
+                        
+                        let keyStr: String
+                        
+                        if let key = keyPair.key.asUInt64(),
+                           let header = Cose.CoseHeader.Headers(rawValue: Int(key)) {
+                            keyStr = "\(header)"
+                            
+                        } else {
+                            if let keyValue = cborToJson(cborObject: keyPair.key, isKey: true, properIssuerItem: properIssuerItem, decodeIssuerAuth: true)  {
+                                keyStr = "\(keyValue)"
+                            } else {
+                                keyStr = "\(keyPair.key)"
+                            }
+                        }
+                        
                         return [
-                            "algorithm": cborToJson(cborObject: keyPair.key, isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true),
-                            "keyId": cborToJson(cborObject: keyPair.value, isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true)
+                            keyStr: cborToJson(cborObject: keyPair.value, isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true)
                         ]
                     })
                 ,

--- a/IOWalletCBOR/IOWalletCBORTests/cborTests.swift
+++ b/IOWalletCBOR/IOWalletCBORTests/cborTests.swift
@@ -636,6 +636,33 @@ final class cborTests: XCTestCase {
             XCTFail("fail to decode")
             return
         }
+        
+        guard let issuerAuth = issuerSigned["issuerAuth"] as? [String: AnyHashable] else {
+            XCTFail("fail to decode")
+            return
+        }
+        
+        guard let unprotectedHeader = issuerAuth["unprotectedHeader"] as? [AnyHashable] else {
+            XCTFail("fail to decode")
+            return
+        }
+        
+        //check if issuerAuth->unprotectedHeader contains x5chain item.
+        XCTAssertFalse(unprotectedHeader.filter({
+            item in
+            
+            if let header = item as? [String: AnyHashable] {
+                
+                return header.keys.contains(where: {
+                    k in
+                    
+                    return k == "x5chain"
+                })
+            }
+            return false
+            
+        }).isEmpty)
+        
 
         guard let nameSpaces = issuerSigned["nameSpaces"] as? [String: AnyHashable] else {
             XCTFail("fail to decode")


### PR DESCRIPTION
## IWP-120

In the credential mapping method from mdoc to json, the keyId parameter contains the certificate value in case of COSE_Sign1 with certificate. 

This behavior can be ambiguous because by specification the certificate chain is contained in the header but in an `x5chain` attribute.

## List of changes proposed in this pull request

- Map unprotectedHeader integer labels to specific keys (ex: 33 -> x5chain) 

## How to test

Test by calling CborCose.decodeCBOR with a cbor encoded object containing issuerAuth and check whether the x5chain field actually exists and is populated

```json

  "issuerSigned": {
    "issuerAuth": {
      "unprotectedHeader": [
        {
          "x5chain": [
            "MIICMjCCAdigAwIBAgIJAM_XjjPEniA7MAoGCCqGSM49BAMCMGwxCzAJBgNVBAYTAklUMQ4wDAYDVQQIDAVMYXppbzENMAsGA1UEBwwEUm9tZTEPMA0GA1UECgwGTW9iaWxlMQ0wCwYDVQQLDARJUFpTMR4wHAYDVQQDDBVJUFpTIElBQ0EgU2VsZi1TaWduZWQwHhcNMjUwMjE0MTcyNTAwWhcNMzUwMjEyMTcyNTAwWjBsMQswCQYDVQQGEwJJVDEOMAwGA1UECAwFTGF6aW8xDTALBgNVBAcMBFJvbWUxDzANBgNVBAoMBk1vYmlsZTENMAsGA1UECwwESVBaUzEeMBwGA1UEAwwVSVBaUyBJQUNBIFNlbGYtU2lnbmVkMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqR4IfnRYdEwQo12oPk0EGtJQrUaWlb_XVUe8MIt8Q_TXChJoBeH-1tHbKIwLNYftjjXQCwPekwbxz2dRGKSIYqNjMGEwHQYDVR0OBBYEFIed8rLRY__FFhH7ka8_oJI4_mbnMB8GA1UdIwQYMBaAFIed8rLRY__FFhH7ka8_oJI4_mbnMA8GA1UdEwEB_wQFMAMBAf8wDgYDVR0PAQH_BAQDAgEGMAoGCCqGSM49BAMCA0gAMEUCIA25MRulze6PjZpwGbz95BnwZ6YsijnBcwBzEudlrNi4AiEAqbUB9kZC9kXKoU1PipkX5_aRuSpUPkSLYVuy5MYWF1c"
          ]
        }
      ]
    }
  }

```
