### PR TITLE
refactor: [IWP-135] Decode unprotectedHeader as Dictionary<String, AnyHashable>

### DIFF
--- a/IOWalletCBOR/IOWalletCBOR/CborCose.swift
+++ b/IOWalletCBOR/IOWalletCBOR/CborCose.swift
@@ -235,40 +235,7 @@ public class CborCose {
             
             return AnyHashable([
                 "protectedHeader": cborToJson(cborObject: issuerAuthCose.protectedHeader.rawHeader, isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true),
-                "unprotectedHeader": decodeUnprotectedHeaders(issuerAuthCose: issuerAuthCose, properIssuerItem)/*
-                    issuerAuthCose.unprotectedHeader?.rawHeader?.asMap()?.map({
-                        keyPair in
-                        
-                        let keyStr: String
-                        var value: AnyHashable? = cborToJson(cborObject: keyPair.value, isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true)
-                        
-                        if let key = keyPair.key.asUInt64(),
-                           let header = Cose.CoseHeader.Headers(rawValue: Int(key)) {
-                            keyStr = "\(header)"
-                            
-                            switch(header) {
-                                case .x5chain, .x5bag:
-                                    //if header is x5chain or x5bag and value is not array transform it to array
-                                    if !(value is [AnyHashable?]) {
-                                        value = [value]
-                                    }
-                                    break
-                                default:
-                                    break
-                            }
-                        } else {
-                            //when header is not in the enum map it as the int value
-                            if let keyValue = cborToJson(cborObject: keyPair.key, isKey: true, properIssuerItem: properIssuerItem, decodeIssuerAuth: true)  {
-                                keyStr = "\(keyValue)"
-                            } else {
-                                keyStr = "\(keyPair.key)"
-                            }
-                        }
-                        return [
-                            keyStr: value
-                        ]
-                    })*/
-                ,
+                "unprotectedHeader": decodeUnprotectedHeaders(issuerAuthCose: issuerAuthCose, properIssuerItem),
                 "signature": issuerAuthCose.signature.base64UrlEncodedString(),
                 "payload": cborToJson(cborObject: try? CBOR.decode(issuerAuthPayload), isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true),
                 "rawValue": Data(issuerAuthValue.encode()).base64UrlEncodedString()

--- a/IOWalletCBOR/IOWalletCBOR/CborCose.swift
+++ b/IOWalletCBOR/IOWalletCBOR/CborCose.swift
@@ -181,13 +181,61 @@ public class CborCose {
         return nil
     }
     
+    private static func decodeUnprotectedHeaders(issuerAuthCose: Cose, _ properIssuerItem: Bool) -> AnyHashable? {
+        let val = issuerAuthCose.unprotectedHeader?.rawHeader?.asMap()?.map({
+            keyPair in
+            
+            let keyStr: String
+            var value: AnyHashable? = cborToJson(cborObject: keyPair.value, isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true)
+            
+            if let key = keyPair.key.asUInt64(),
+               let header = Cose.CoseHeader.Headers(rawValue: Int(key)) {
+                keyStr = "\(header)"
+                
+                switch(header) {
+                    case .x5chain, .x5bag:
+                        //if header is x5chain or x5bag and value is not array transform it to array
+                        if !(value is [AnyHashable?]) {
+                            value = [value]
+                        }
+                        break
+                    default:
+                        break
+                }
+            } else {
+                //when header is not in the enum map it as the int value
+                if let keyValue = cborToJson(cborObject: keyPair.key, isKey: true, properIssuerItem: properIssuerItem, decodeIssuerAuth: true)  {
+                    keyStr = "\(keyValue)"
+                } else {
+                    keyStr = "\(keyPair.key)"
+                }
+            }
+            return Dictionary<String, AnyHashable?>.Element(
+                keyStr, value
+            )
+        })
+        
+        if let val = val {
+            let dictionary = Dictionary(uniqueKeysWithValues: val)
+            
+            return dictionary
+        }
+        
+        
+        return nil
+        
+    }
+    
     private static func decodeIssuerAuthValue(_ issuerAuthValue: CBOR?, _ properIssuerItem: Bool) -> AnyHashable? {
         if let issuerAuthValue = issuerAuthValue,
            let issuerAuthCose = Cose.init(type: .sign1, cbor: issuerAuthValue),
            let issuerAuthPayload = issuerAuthCose.payload.asBytes() {
+            
+            
+            
             return AnyHashable([
                 "protectedHeader": cborToJson(cborObject: issuerAuthCose.protectedHeader.rawHeader, isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true),
-                "unprotectedHeader":
+                "unprotectedHeader": decodeUnprotectedHeaders(issuerAuthCose: issuerAuthCose, properIssuerItem)/*
                     issuerAuthCose.unprotectedHeader?.rawHeader?.asMap()?.map({
                         keyPair in
                         
@@ -219,7 +267,7 @@ public class CborCose {
                         return [
                             keyStr: value
                         ]
-                    })
+                    })*/
                 ,
                 "signature": issuerAuthCose.signature.base64UrlEncodedString(),
                 "payload": cborToJson(cborObject: try? CBOR.decode(issuerAuthPayload), isKey: false, properIssuerItem: properIssuerItem, decodeIssuerAuth: true),

--- a/IOWalletCBOR/IOWalletCBORTests/cborTests.swift
+++ b/IOWalletCBOR/IOWalletCBORTests/cborTests.swift
@@ -593,6 +593,55 @@ final class cborTests: XCTestCase {
 
         print(json)
     }
+    
+    static let mdlIWP135 = "omppc3N1ZXJBdXRohEOhASaiBFgra3pvdURGejdObGhHX2NXMDBNWF9lNWJmbUdtTVJDSDRVT3h6eTE2VHFKWRghWQL3MIIC8zCCApigAwIBAgIUTJC/o0Xh0EG9oYV7aA6jbL1VqdEwCgYIKoZIzj0EAwIwczELMAkGA1UEBhMCSVQxDjAMBgNVBAgMBUl0YWx5MQ0wCwYDVQQHDARSb21lMRMwEQYDVQQKDApQYWdvUEEgc3BhMRIwEAYDVQQLDAlJTyBXYWxsZXQxHDAaBgNVBAMME2lvLndhbGxldC5wYWdvcGEuaXQwHhcNMjUwNjE3MjAzNjIyWhcNMjYwNjE3MjAzNjIyWjBzMQswCQYDVQQGEwJJVDEOMAwGA1UECAwFSXRhbHkxDTALBgNVBAcMBFJvbWUxEzARBgNVBAoMClBhZ29QQSBzcGExEjAQBgNVBAsMCUlPIFdhbGxldDEcMBoGA1UEAwwTaW8ud2FsbGV0LnBhZ29wYS5pdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABBsKqvOYaFqtMLddW7ivV2MwhjMQrNk22WXT1yu6MazQr9qCI5w/8PJ093eFDjXUZ43/Sd822lZNS1EPLQ6ty8WjggEIMIIBBDAdBgNVHQ4EFgQUYHzWTXU4w485WQf/uomDzX9LzqkwHwYDVR0jBBgwFoAUYHzWTXU4w485WQf/uomDzX9LzqkwEgYDVR0TAQH/BAgwBgEB/wIBADAOBgNVHQ8BAf8EBAMCAQYwSwYDVR0SBEQwQoZAaHR0cHM6Ly9pby1kLWl0bi13YWxsZXQtaXNzdWVyLWZ1bmMtMDEuYXp1cmV3ZWJzaXRlcy5uZXQvY3JsLnBlbTBRBgNVHR8ESjBIMEagRKBChkBodHRwczovL2lvLWQtaXRuLXdhbGxldC1pc3N1ZXItZnVuYy0wMS5henVyZXdlYnNpdGVzLm5ldC9jcmwucGVtMAoGCCqGSM49BAMCA0kAMEYCIQDxAFoOimieb8o6IjEyECeAaQ0z8GZXVwE3DkHV4qspQwIhAK6aX8k+2PK0VzdFnRE1LUnZzFOGb1e0bvJJz2fTYBbBWQLN2BhZAsi5AAZndmVyc2lvbmMxLjBvZGlnZXN0QWxnb3JpdGhtZ1NIQS0yNTZsdmFsdWVEaWdlc3RzoXFvcmcuaXNvLjE4MDEzLjUuMaoAWCDtKjqNxI094xm+ERsscKkuG5qEFsvjsyIf7k3D6g/DJANYICZZmUPdPolTOEL7KfwSs8JPfJXIaCSgy/PANkU59G9DAlggphQOLMGZrwJCO2aAR0EqUErNzEPMb14Jw4VNLc4o3UQBWCB4GXbezGUJCocW3RUIfY3zCRZynNtjnGECAbldETw6OARYIAl8topnp7NamXmmACI7bIpnPnz9h9r8DyIesZvq4ZOBBVggWP1ZSEyDdkVvtOwcQExw29qtYrJkH6IRao8yV+1ICLcGWCBanogLQMHRY1vGiusYqnv5wXuGgBhBbimHWR/t6MxpVAdYIP0HnVMVsADvvCIViM+KDSZoP7fZb6GYh2CIZ2uA8NSGCFgguquGcEww6GKdKHiqDer2iPkHMCSntR7KhdmTuz52jxIJWCCsA6K+FOWMb9c7LksHycJM3iUfV4ckWTzbXeiZPlbDjG1kZXZpY2VLZXlJbmZvuQABaWRldmljZUtleaYDJiABAngra3pvdURGejdObGhHX2NXMDBNWF9lNWJmbUdtTVJDSDRVT3h6eTE2VHFKWQECIVgg3KZRbvgZTDt6NgAbg8zHJtjQS6FHD6WeOEC7YbI+Z54iWCDk1IdRphtTbm1eruYmkKhdQWaI3lsq547/o8yxDiulImdkb2NUeXBldW9yZy5pc28uMTgwMTMuNS4xLm1ETGx2YWxpZGl0eUluZm+5AANmc2lnbmVkwHQyMDI1LTA2LTE3VDIxOjAzOjM4Wml2YWxpZEZyb23AdDIwMjUtMDYtMTdUMjE6MDM6MzhaanZhbGlkVW50aWzAdDIwMjUtMDYtMTdUMjE6MDM6MzhaWEAP7aj0XNVqf6kKrDSL5pPumOEM+SmRKXjpKtaEIkmPOlnGMGpkmqFNftccBxVG4jKMdOuB9XxjA4T6MwmVItlFam5hbWVTcGFjZXOhcW9yZy5pc28uMTgwMTMuNS4xitgYWGykaGRpZ2VzdElEAHFlbGVtZW50SWRlbnRpZmllcmpiaXJ0aF9kYXRlbGVsZW1lbnRWYWx1ZdkD7GoyMDA3LTAzLTI1ZnJhbmRvbVgg2wMo4mZF+meLHpA2rjZ7kJceBNqvQnGtPTeR/b9qYZbYGFhvpGhkaWdlc3RJRAFxZWxlbWVudElkZW50aWZpZXJvZG9jdW1lbnRfbnVtYmVybGVsZW1lbnRWYWx1ZWswMS04NTYtNTA1MGZyYW5kb21YICLKp10d7e0uU3g6OT+/QAy2mRhRFzEm6Sw04UWxZXIj2BhZAQOkaGRpZ2VzdElEAnFlbGVtZW50SWRlbnRpZmllcnJkcml2aW5nX3ByaXZpbGVnZXNsZWxlbWVudFZhbHVlgrkAA2tleHBpcnlfZGF0ZdkD7GoyMDI2LTA5LTIwamlzc3VlX2RhdGXZA+xqMjAyMS0wOS0wMnV2ZWhpY2xlX2NhdGVnb3J5X2NvZGVhQbkAA2tleHBpcnlfZGF0ZdkD7GoyMDI3LTA5LTIwamlzc3VlX2RhdGXZA+xqMjAyMi0wOS0wMnV2ZWhpY2xlX2NhdGVnb3J5X2NvZGVhQmZyYW5kb21YIIfzL+Ft897ezalAHhuxM3/61KUspYTdJ5ks1lzh209d2BhYdaRoZGlnZXN0SUQDcWVsZW1lbnRJZGVudGlmaWVya2V4cGlyeV9kYXRlbGVsZW1lbnRWYWx1ZcB0MjAyOC0wOS0zMFQwMDowMDowMFpmcmFuZG9tWCDJ7oBHcjjFeJmSulM2lozFG2Nyss0nIv6zpxx0WX4SSNgYWGWkaGRpZ2VzdElEBHFlbGVtZW50SWRlbnRpZmllcmtmYW1pbHlfbmFtZWxlbGVtZW50VmFsdWVlSm9uZXNmcmFuZG9tWCA6GXO6lh6RDkKPi18jm2xiydP6z987wlQRWIDTjLoGEtgYWGKkaGRpZ2VzdElEBXFlbGVtZW50SWRlbnRpZmllcmpnaXZlbl9uYW1lbGVsZW1lbnRWYWx1ZWNBdmFmcmFuZG9tWCBY4LzQ350vrhw0PkLklqSeecpUYR5vS+Lw4Eip9CQiLNgYWHSkaGRpZ2VzdElEBnFlbGVtZW50SWRlbnRpZmllcmppc3N1ZV9kYXRlbGVsZW1lbnRWYWx1ZcB0MjAyMy0wOS0wMVQwMDowMDowMFpmcmFuZG9tWCDwxG+1bsIoYby0o9MXTB+RwYoCZ4LlsdxlzMNly1QJ8NgYWGykaGRpZ2VzdElEB3FlbGVtZW50SWRlbnRpZmllcnFpc3N1aW5nX2F1dGhvcml0eWxlbGVtZW50VmFsdWVmTlkgRE1WZnJhbmRvbVggLatRve3dmq8yqR1yye9naja+zvIn4BOUKMseDVYGFcjYGFhmpGhkaWdlc3RJRAhxZWxlbWVudElkZW50aWZpZXJvaXNzdWluZ19jb3VudHJ5bGVsZW1lbnRWYWx1ZWJVU2ZyYW5kb21YIML5EhTdmgVcDlHMGWjO5E43VY6jIfG5qNTHC7Hek/Iu2BhYYaRoZGlnZXN0SUQJcWVsZW1lbnRJZGVudGlmaWVyaHBvcnRyYWl0bGVsZW1lbnRWYWx1ZWRic3RyZnJhbmRvbVggWc9blSZb8tVsb7r2g6vFsLLG3Tz3429nY7P/mMw5WTE="
+    
+    func testDecodeIWP135() {
+        guard let jsonString = CborCose.decodeCBOR(data: Data(base64Encoded: cborTests.mdlIWP135)!, false)
+        else {
+            XCTFail("fail to decode")
+            return
+        }
+
+        print(jsonString)
+        
+        guard let jsonData = jsonString.data(using: .utf8),
+            let json = try? JSONSerialization.jsonObject(with: jsonData)
+        else {
+            XCTFail("fail to decode")
+            return
+        }
+        
+        guard let issuerSigned = json as? [String: AnyHashable] else {
+            XCTFail("fail to decode")
+            return
+        }
+        
+        guard let issuerAuth = issuerSigned["issuerAuth"] as? [String: AnyHashable] else {
+            XCTFail("fail to decode")
+            return
+        }
+        
+        //check if unprotectedHeader is a Map<String, Any>
+        guard let unprotectedHeader = issuerAuth["unprotectedHeader"] as? [String: AnyHashable] else {
+            XCTFail("fail to decode")
+            return
+        }
+        
+        
+        //check if issuerAuth->unprotectedHeader contains x5chain item & kid item.
+        XCTAssertFalse(unprotectedHeader.keys.filter({
+            k in
+            return k == "x5chain"
+        }).isEmpty)
+        
+        XCTAssertFalse(unprotectedHeader.keys.filter({
+            k in
+            return k == "kid"
+        }).isEmpty)
+        
+        print(json)
+    }
 
     func testDecodeCBOR() {
         guard let jsonString = CborCose.decodeCBOR(data: Data(base64Encoded: cborTests.document1)!)
@@ -642,25 +691,15 @@ final class cborTests: XCTestCase {
             return
         }
         
-        guard let unprotectedHeader = issuerAuth["unprotectedHeader"] as? [AnyHashable] else {
+        guard let unprotectedHeader = issuerAuth["unprotectedHeader"] as? [String: AnyHashable] else {
             XCTFail("fail to decode")
             return
         }
         
         //check if issuerAuth->unprotectedHeader contains x5chain item.
-        XCTAssertFalse(unprotectedHeader.filter({
-            item in
-            
-            if let header = item as? [String: AnyHashable] {
-                
-                return header.keys.contains(where: {
-                    k in
-                    
-                    return k == "x5chain"
-                })
-            }
-            return false
-            
+        XCTAssertFalse(unprotectedHeader.keys.filter({
+            k in
+            return k == "x5chain"
         }).isEmpty)
         
 


### PR DESCRIPTION
## IWP-135

Decode unprotectedHeader as `Dictionary<String, AnyHashable>`

## How to test

Test by calling CborCose.decodeCBOR with a cbor encoded object containing issuerAuth and check whether the unprotectedHeader field actually exists and is a Map<String, AnyHashable>

```json
{
  "unprotectedHeader": {
    "x5chain": [
      "MIIC8zCCApigAwIBAgIUTJC_o0Xh0EG9oYV7aA6jbL1VqdEwCgYIKoZIzj0EAwIwczELMAkGA1UEBhMCSVQxDjAMBgNVBAgMBUl0YWx5MQ0wCwYDVQQHDARSb21lMRMwEQYDVQQKDApQYWdvUEEgc3BhMRIwEAYDVQQLDAlJTyBXYWxsZXQxHDAaBgNVBAMME2lvLndhbGxldC5wYWdvcGEuaXQwHhcNMjUwNjE3MjAzNjIyWhcNMjYwNjE3MjAzNjIyWjBzMQswCQYDVQQGEwJJVDEOMAwGA1UECAwFSXRhbHkxDTALBgNVBAcMBFJvbWUxEzARBgNVBAoMClBhZ29QQSBzcGExEjAQBgNVBAsMCUlPIFdhbGxldDEcMBoGA1UEAwwTaW8ud2FsbGV0LnBhZ29wYS5pdDBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABBsKqvOYaFqtMLddW7ivV2MwhjMQrNk22WXT1yu6MazQr9qCI5w_8PJ093eFDjXUZ43_Sd822lZNS1EPLQ6ty8WjggEIMIIBBDAdBgNVHQ4EFgQUYHzWTXU4w485WQf_uomDzX9LzqkwHwYDVR0jBBgwFoAUYHzWTXU4w485WQf_uomDzX9LzqkwEgYDVR0TAQH_BAgwBgEB_wIBADAOBgNVHQ8BAf8EBAMCAQYwSwYDVR0SBEQwQoZAaHR0cHM6Ly9pby1kLWl0bi13YWxsZXQtaXNzdWVyLWZ1bmMtMDEuYXp1cmV3ZWJzaXRlcy5uZXQvY3JsLnBlbTBRBgNVHR8ESjBIMEagRKBChkBodHRwczovL2lvLWQtaXRuLXdhbGxldC1pc3N1ZXItZnVuYy0wMS5henVyZXdlYnNpdGVzLm5ldC9jcmwucGVtMAoGCCqGSM49BAMCA0kAMEYCIQDxAFoOimieb8o6IjEyECeAaQ0z8GZXVwE3DkHV4qspQwIhAK6aX8k-2PK0VzdFnRE1LUnZzFOGb1e0bvJJz2fTYBbB"
    ],
    "kid": "a3pvdURGejdObGhHX2NXMDBNWF9lNWJmbUdtTVJDSDRVT3h6eTE2VHFKWQ"
  }
}
```

